### PR TITLE
Update bin help command

### DIFF
--- a/bin/run-create-sdkgen.js
+++ b/bin/run-create-sdkgen.js
@@ -296,7 +296,10 @@ Usage: npm create @voxgig/sdkgen@latest <name> <args>
     -d                       that defines the SDK. Optional.
 
     --model <file>         Specify the SDK model file to customize the SDK. Optional.
-    -m                       
+    -m
+    
+    --feature <name>       Specify a feature to include in the SDK. Can be specified multiple times.
+    -t <name>
 
     --watch                Run in watch mode. The SDK project will be updated if any of the
     -w                       project inputs (such as the spec file) change.

--- a/bin/run-create-sdkgen.js
+++ b/bin/run-create-sdkgen.js
@@ -302,7 +302,7 @@ Usage: npm create @voxgig/sdkgen@latest <name> <args>
     -w                       project inputs (such as the spec file) change.
 
     --debug                Print verbose logging.
-    -d                       
+    -g                    
 
     --help                 Print this help message.
     -h


### PR DESCRIPTION
This PR updates the documentation in the help command output to correctly display the verbose logging flag as `-g` instead of `-d`. Additionally, it adds documentation for the new `--feature` `-t` command to include a feature.