### PR TITLE
tsconfig: add types: [node] for TS 6 compatibility

### DIFF
--- a/project/standard/.sdk/src/tsconfig.json
+++ b/project/standard/.sdk/src/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2021",
+    "types": ["node"],
     "declaration": true,
     "declarationDir": "../dist"
   },


### PR DESCRIPTION
## Summary
- Scaffolded SDK projects fail to compile under TypeScript 6 because `@types/node` is no longer auto-included with `module: "nodenext"`.
- Adds `"types": ["node"]` to the `.sdk/src` tsconfig template so the scaffolded project compiles cleanly on TS 6 (and remains a no-op on TS 5).

## Background
With TypeScript 6.0.x and `module: "nodenext"`, the implicit inclusion of all `@types/*` packages tightened up. Without an explicit `types` entry, code that uses `import { ... } from "node:util"` or the `global` ambient hits `TS2591`/`TS2304` errors.

Sister fix: voxgig/sdkgen#7 (same change applied to the `tm/ts/src` and `tm/ts/test` templates in that repo).

## Test plan
- [x] Reproduce failure on TS 6.0.3 with the current template
- [x] Verify `tsc --build .sdk` passes after the change