### PR TITLE
scaffold: aontu comment syntax, and generate the test corpus

### DIFF
--- a/project/standard/.sdk/model/.model-config/model-config.aontu
+++ b/project/standard/.sdk/model/.model-config/model-config.aontu
@@ -5,7 +5,7 @@
 sys: model: action: {
   apidef: load: 'build/apidef.js'
   sdkgen: load: 'build/sdkgen.js'
-  // docgen: load: 'build/docgen.js'
+  # docgen: load: 'build/docgen.js'
 }
 
 sys: model: order: action: 'apidef,sdkgen'

--- a/project/standard/.sdk/package.json
+++ b/project/standard/.sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "$$const.Name$$ SDK Project",
   "scripts": {
-    "generate": "tsc --build src && voxgig-model model/sdk.aontu",
+    "generate": "tsc --build src && voxgig-model model/sdk.aontu && voxgig-model test/test.aontu",
     "watch-generate": "voxgig-model -w model/sdk.aontu",
     "dry-generate": "tsc --build src && voxgig-model -y model/sdk.aontu",
     "watch-dry-generate": "voxgig-model -w -y model/sdk.aontu",


### PR DESCRIPTION
Two defects that both surfaced generating a fresh SDK on 2026-08-07.

## 1. `model-config.aontu` shipped a `//` comment

aontu only accepts `#`, so **generation failed outright on a brand-new scaffold**:

```
[aontu/unexpected]: unexpected character(s): //
  --> .sdk/model/.model-config/model-config.aontu:8:3
   8 |   // docgen: load: 'build/docgen.js'
        ^^ unexpected character(s): //
```

The error message even names the fix ("Use the `#` character"). One line.

## 2. `npm run generate` did not rebuild `test/test.json`

The corpus is built by `voxgig-model test/test.aontu`, which only ran under the separate `test-model` script. So editing a fixture in `.sdk/test/primary/` and running the documented `generate` command left `test.json` stale — and the go target's zero-case guard then failed a suite the fixtures had already fixed:

```
test corpus section "preparePath" is EMPTY - zero cases would run;
add cases, or mark the fixture PENDING in .sdk/test/primary/
```

That costs a debugging cycle every time, because `generate` reports success. `generate` now builds the test model too, so a generated SDK is complete and testable in one command.

## Verification

From a clean scaffold with the local build: `generate` exits 0, and the corpus comes out populated — `preparePath` 6 cases, `clean` 4, `prepareQuery` 5.

## Note for release

**The published `0.16.4` is stale relative to `main`.** It predates the corpus fixtures in `2c49b2b` / `8ec031a`, so every SDK scaffolded from npm today gets empty `preparePath`/`clean` sections and fails go tests out of the box — which is exactly how this was found. A version bump and publish fixes more than these two changes do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZeNN7c2Q1w3m3bNAJJYHU