### PR TITLE
feat: corpus cases for spec-supplied HTTP methods, move to aontu 0.49

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+# Publishes @voxgig/create-sdkgen to npm on a `v*` tag push, via GitHub
+# OIDC Trusted Publishing — no NPM_TOKEN secret. The `id-token: write`
+# permission lets npm exchange a GitHub OIDC token for a short-lived
+# publish credential, and provenance is attached automatically.
+#
+# The trusted publisher must be registered on npmjs.com for
+# voxgig/create-sdkgen against THIS filename (publish.yml); renaming
+# this file breaks publishing until the npm-side config is updated to
+# match.
+#
+# Release flow: bump package.json, merge to main, then push a v* tag.
+
+name: publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1.
+      - name: Use a trusted-publishing capable npm
+        run: npm install -g npm@latest
+
+      # package-lock.json is committed here, so ci is safe and reproducible.
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@voxgig/create-sdkgen",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@voxgig/create-sdkgen",
-      "version": "0.16.5",
+      "version": "0.16.6",
       "license": "MIT",
       "dependencies": {
         "@voxgig/util": "0.5.4",
-        "aontu": "0.48.2",
+        "aontu": "0.49.0",
         "chokidar": "5.0.0",
         "jostraca": "0.31.2",
         "shape": "10.1.3"
@@ -442,9 +442,9 @@
       "peer": true
     },
     "node_modules/@tabnas/debug": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@tabnas/debug/-/debug-0.2.5.tgz",
-      "integrity": "sha512-y+W825wR66n7Ue/oZK6am/upQ5ziUKH4gEYIObfmQm2UAf/2RYqJHybtAnZGu+56METLUjjIhZgDmaSboklfNA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@tabnas/debug/-/debug-0.2.9.tgz",
+      "integrity": "sha512-1p5jvIxcfUdTGTkCV/WMadYbSuMeTRHLwyAxJcUs1ykn++jaOV6069tSj62OEvifRS+5wIGE8pBBc9vEL0lsdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -454,9 +454,9 @@
       }
     },
     "node_modules/@tabnas/directive": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tabnas/directive/-/directive-0.2.1.tgz",
-      "integrity": "sha512-KVfgdRUAy/oJraIDTG2gdZf5Rk35+vDRcRBPGkZhZCUCaiF2JvfFn7Rj6L7Ugvh7sJgnA7gesKyPu97Xee0PTQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tabnas/directive/-/directive-0.4.2.tgz",
+      "integrity": "sha512-GSjgGWF0R2pd0b6EuYApENgW+yFgSeZeNqoVgwnI9hThgz6WpjlZZeLKEqoYqVj2DESuOH3xwOJcMlVkzDoR/w==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@tabnas/expr": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@tabnas/expr/-/expr-0.2.3.tgz",
-      "integrity": "sha512-18oXtsJj/iMIH86HmHSwgBevNR9Mlu1f75KYAShvJMg1hWGQZfeliByItXidohV7a906Wy/2FGNgrOvgxUd0PQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tabnas/expr/-/expr-0.4.2.tgz",
+      "integrity": "sha512-eFUjM3O+YCLU+PU/va+/fOWgnv2nVWyYYGTlS4DCnTH4cdpIIKsYLJ6khOY0YLNrLv3TMETHvV4og/7gqEPyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@tabnas/json": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@tabnas/json/-/json-0.4.1.tgz",
-      "integrity": "sha512-E2qTSlYSh/VM8OLPzaWizXBrozbZB+W9VPw4MSQFn3mjycvA2Qk3AHQmdy+4yiYPz3vRO+IN0SgJB4p99W6SOg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@tabnas/json/-/json-0.4.3.tgz",
+      "integrity": "sha512-WkUxFlCWdYufu8TJvJnSNHv5cEU6PLXBN5x1QLlrOVh/f5F9WFLG7LihnoWBYYZxiERJU6eho6on+NxKyKhBNg==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/@tabnas/jsonic": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@tabnas/jsonic/-/jsonic-0.3.1.tgz",
-      "integrity": "sha512-m1+SFzfDKDIUP4SfRohhYeioeKMPnmhjpBMq4ZdJ21cpe7Qfz65iFgddzVppORxz2uJg6kckMCwIEt4eGnGMDg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@tabnas/jsonic/-/jsonic-0.4.3.tgz",
+      "integrity": "sha512-Ah+C0CWJwlQfM2NY2L763chB8I4tXNKlq4TCPI1Z48vomNu7JDm0LYbWpmTmujuWvLsT7QUmwKBXwkeGEurEnQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@tabnas/multisource": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@tabnas/multisource/-/multisource-0.3.2.tgz",
-      "integrity": "sha512-PBhPBWIvUH4ZhENiwQ1xJtHT29pwk9D0orxs53rowY5oroCLdbaMUs6aXXmyGoT2yeD7fKuIY1w1/LXBmx2Mhg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tabnas/multisource/-/multisource-0.4.4.tgz",
+      "integrity": "sha512-oN2kOaOCFx5StzG3B3qOEEkYjWLfyZGzfagtaAJSw42HyY25zdIpJmgupcS3YOhCgj/EPbfh7q4Dr+gCeyQCZg==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -523,19 +523,18 @@
       }
     },
     "node_modules/@tabnas/parser": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@tabnas/parser/-/parser-0.4.1.tgz",
-      "integrity": "sha512-rLvH/spXpjkEyAezHamBWW3xNQFcs1uPQ0hzCzV2zPisK0d2DSg9O8xT38IDFMDIGwEO84EB1fcp8X9wkEsYWw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@tabnas/parser/-/parser-0.6.2.tgz",
+      "integrity": "sha512-tjGc3eZhBGGVC8f55KlXFKBkWZtCGBGhCzzzKQIcCQmcPr4ldj0EidCrV1f6HhXlXguk8ZyvJH0r1nybvjbJYg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@tabnas/path": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tabnas/path/-/path-0.2.1.tgz",
-      "integrity": "sha512-hGxyIVL+sAU4G61yevenxuDnoDJL3a5VecRzqDuTQJOF/N9chlZOZkD/FvVbEGY61Fat5knoguSMFEx5OiaNdg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@tabnas/path/-/path-0.2.3.tgz",
+      "integrity": "sha512-ES3SUYN+SGT6922axLWQjBK71ZIh5S1/MVW9o20euKZixqxMyEsJX6lN9ZPPcE5OCOtfjoniry6CvFmikiuXnw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -906,17 +905,18 @@
       }
     },
     "node_modules/aontu": {
-      "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/aontu/-/aontu-0.48.2.tgz",
-      "integrity": "sha512-GRfPWg1YUljIp4A9SMENcCF4WlKBhMY/ZqCL30T+O63Y/BzSFNY3mr45yYBLIhJUzM7atZcY9Y1tRmGaqHYdbg==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/aontu/-/aontu-0.49.0.tgz",
+      "integrity": "sha512-Q1T0WTPvFo4QVptipOe/pGQRHjOmmWoIZh1JGrYeIoWOzuje+vbc/HqtkzXQtLWj6pZ8bo7vhBPtdhyGR+RRDw==",
       "license": "MIT",
       "dependencies": {
-        "@tabnas/debug": "0.2.5",
-        "@tabnas/directive": "0.2.1",
-        "@tabnas/expr": "0.2.3",
-        "@tabnas/jsonic": "0.3.1",
-        "@tabnas/multisource": "0.3.2",
-        "@tabnas/path": "0.2.1"
+        "@tabnas/debug": "0.2.9",
+        "@tabnas/directive": "0.4.2",
+        "@tabnas/expr": "0.4.2",
+        "@tabnas/jsonic": "0.4.3",
+        "@tabnas/multisource": "0.4.4",
+        "@tabnas/parser": "0.6.2",
+        "@tabnas/path": "0.2.3"
       },
       "bin": {
         "aontu": "dist/cli.js",
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
-      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+      "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
       "license": "MIT",
       "peer": true
     },
@@ -1169,9 +1169,9 @@
       "peer": true
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",
@@ -1204,9 +1204,9 @@
       "peer": true
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -1296,9 +1296,9 @@
       }
     },
     "node_modules/thingies": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voxgig/create-sdkgen",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "main": "dist/create-sdkgen.js",
   "type": "commonjs",
   "types": "dist/create-sdkgen.d.ts",
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@voxgig/util": "0.5.4",
-    "aontu": "0.48.2",
+    "aontu": "0.49.0",
     "chokidar": "5.0.0",
     "jostraca": "0.31.2",
     "shape": "10.1.3"

--- a/project/standard/.sdk/test/primary/prepareMethod.aontu
+++ b/project/standard/.sdk/test/primary/prepareMethod.aontu
@@ -7,4 +7,20 @@ basic: set: [
   { ctx: { opname:remove }, out: DELETE }
 
   { ctx: { opname:bad } }
+
+  # The point's method comes from the API definition and wins over the
+  # op-name convention: POST-only APIs expose `update` and `remove` as POST,
+  # and PATCH-based APIs expose `update` as PATCH.
+  { ctx: { opname:update, point: { method: POST } }, out: POST }
+  { ctx: { opname:update, point: { method: PATCH } }, out: PATCH }
+  { ctx: { opname:remove, point: { method: POST } }, out: POST }
+  { ctx: { opname:load, point: { method: POST } }, out: POST }
+  { ctx: { opname:create, point: { method: POST } }, out: POST }
+
+  # A lowercase method is normalised to the canonical uppercase verb.
+  { ctx: { opname:update, point: { method: post } }, out: POST }
+
+  # No usable method on the point falls back to the op-name convention.
+  { ctx: { opname:update, point: { method: "" } }, out: PUT }
+  { ctx: { opname:remove, point: { } }, out: DELETE }
 ]

--- a/project/standard/.sdk/test/test.json
+++ b/project/standard/.sdk/test/test.json
@@ -17375,6 +17375,76 @@
             "ctx": {
               "opname": "bad"
             }
+          },
+          {
+            "ctx": {
+              "opname": "update",
+              "point": {
+                "method": "POST"
+              }
+            },
+            "out": "POST"
+          },
+          {
+            "ctx": {
+              "opname": "update",
+              "point": {
+                "method": "PATCH"
+              }
+            },
+            "out": "PATCH"
+          },
+          {
+            "ctx": {
+              "opname": "remove",
+              "point": {
+                "method": "POST"
+              }
+            },
+            "out": "POST"
+          },
+          {
+            "ctx": {
+              "opname": "load",
+              "point": {
+                "method": "POST"
+              }
+            },
+            "out": "POST"
+          },
+          {
+            "ctx": {
+              "opname": "create",
+              "point": {
+                "method": "POST"
+              }
+            },
+            "out": "POST"
+          },
+          {
+            "ctx": {
+              "opname": "update",
+              "point": {
+                "method": "post"
+              }
+            },
+            "out": "POST"
+          },
+          {
+            "ctx": {
+              "opname": "update",
+              "point": {
+                "method": ""
+              }
+            },
+            "out": "PUT"
+          },
+          {
+            "ctx": {
+              "opname": "remove",
+              "point": {}
+            },
+            "out": "DELETE"
           }
         ]
       }


### PR DESCRIPTION
Companion to [voxgig/sdkgen#19](https://github.com/voxgig/sdkgen/pull/19) — adds the shared corpus cases that cover the `prepareMethod` fix.

## prepareMethod corpus

Adds cases asserting that the point's method — **the verb the API definition supplies** — wins over the op-name convention:

- `update` as POST, and as PATCH
- `remove` as POST
- a lowercase method normalised to uppercase

Plus the fallback cases: an empty method, and a point with no method, both fall back to the op-name map.

This corpus drives **all 23 target languages from one place**, so these cases cover the `prepareMethod` fix in `@voxgig/sdkgen@1.4.0` without per-language tests.

## test.json regenerated

Generated SDKs execute the compiled `test.json`, **not** the `.aontu` fixtures — so an edited fixture that was never recompiled changes nothing for any target. Recompiled through the same aontu path the corpus test uses: `prepareMethod` goes from **6 → 14 cases**.

The `corpus.test.ts` guard is what caught this. It compares fixture *content* against `test.json` rather than case counts, which is exactly the "green while checking nothing" failure it exists to prevent.

## Dependencies

`aontu` `0.48.2` → `0.49.0`.

## Publishing

Adds `.github/workflows/publish.yml` — trusted publishing on `v*` tags via OIDC, no `NPM_TOKEN`, provenance attached automatically. `npm ci` is safe here because `package-lock.json` is committed.

## Verification

30 tests pass on a clean install, resolving `aontu@0.49.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTGhF3edzZ7oJTpz2QLWnS