### PR TITLE
Root.ts: filter inactive entities before generating their files

### DIFF
--- a/project/standard/.sdk/src/Root.ts
+++ b/project/standard/.sdk/src/Root.ts
@@ -105,7 +105,7 @@ const Root = cmp(function Root(props: any) {
           false !== (phase[name] && phase[name].active)
 
         if (phaseActive('entity')) {
-          each(entity, (entity: any) => {
+          each(entity).filter((entity: any) => entity.active).map((entity: any) => {
             names(entity, entity.name)
             Entity({ target, entity })
           })


### PR DESCRIPTION
## Summary

The entity loop in `Root.ts` looped over `model.main[KIT].entity` raw, unlike the feature loop right below it (`each(feature).filter(f => f.active)`) — an entity marked `active: false` in the project's own `sdk.aontu` still got a full generated source file, contradicting sdkgen's documented `main.kit.entity.<name>.active`: "Whether the entity is generated."

`Root.ts` is scaffolded once here and then treated as project-owned (`@voxgig/sdkgen` ships no copy of its own), so this is the only place to fix it.

Found while converting `senecajs/seneca-trello-provider` to a generated `seneca-provider` plugin: scoping the SDK down to one entity via `active: false` left 69 stray entity source files in the generated SDK.

## Related PR

`@voxgig/sdkgen` had the identical bug independently in three places (`Test_<lang>.ts` for all languages, `ExternalTarget.ts`, and the test harness's own `Root.ts` replica) — fixed separately in voxgig/sdkgen#40, since `sdkgen` carries no copy of this file.

## Changes

- `project/standard/.sdk/src/Root.ts`: one-line fix, `each(entity, ...)` → `each(entity).filter(entity => entity.active).map(...)`

## Test plan

- [x] `npm run build && npm test` — 37/37 pass (this repo's own suite only covers scaffolding, not generation, so it can't directly exercise this runtime behavior)
- [x] Verified end to end by regenerating a real multi-entity SDK (Trello's official OpenAPI spec, 70 apidef-derived entities) scoped down to one active entity via a locally-linked, fixed `create-sdkgen` + `sdkgen`: before this fix, all 70 entities got source files; after, just the one
- [x] `@voxgig/sdkgen`'s test suite carries a replica of this loop (`test/generateharness.ts`'s `makeRoot`) with the matching fix + a new regression test, since it's the only place this logic can be exercised automatically