### PR TITLE
ci: adopt apidef's release mechanism — publish and tag in one dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,12 +179,48 @@ jobs:
             echo "$V is not on npm — will publish"
           fi
 
+      # SKIPPING THE PUBLISH ASSUMES "SAME VERSION MEANS SAME CODE". That holds
+      # only if main has not moved. Publish succeeds at commit A, the tag job
+      # fails, main advances to B, someone re-dispatches: the version is still
+      # on npm, so the publish is skipped and B gets tagged — while the
+      # registry artifact was built from A. The tag would then point at code
+      # the published package does not contain.
+      #
+      # npm records the source commit as `gitHead`, so this is checkable.
+      # Absent gitHead (an old or non-git publish) cannot be verified, so warn
+      # rather than block — refusing would make legitimate recovery impossible.
+      - name: A published version must come from this commit
+        if: ${{ steps.registry.outputs.published == 'true' }}
+        run: |
+          set -euo pipefail
+          V="${{ steps.versions.outputs.version }}"
+          GH="$(npm view "@voxgig/create-sdkgen@$V" gitHead 2>/dev/null || true)"
+          if [ -z "$GH" ]; then
+            echo "::warning::npm records no gitHead for $V; cannot verify it was built from this commit"
+          elif [ "$GH" != "$GITHUB_SHA" ]; then
+            echo "::error::npm has $V built from $GH, but this run is $GITHUB_SHA — tagging would point at code the registry does not contain"
+            exit 1
+          else
+            echo "$V on npm was built from this commit"
+          fi
+
       # Publish BEFORE tagging (the tag job `needs` this one), so a tag only
       # ever exists for a release that reached the registry.
       - name: Publish to npm
         if: ${{ steps.registry.outputs.published == 'false' }}
         working-directory: .
-        run: npm publish --access public
+        run: |
+          set -euo pipefail
+          V="${{ steps.versions.outputs.version }}"
+          # A PRERELEASE MUST NOT BECOME `latest`. `npm publish` defaults to
+          # the latest dist-tag, so publishing 1.2.3-beta.1 that way hands it
+          # to every unpinned install.
+          case "$V" in
+            *-*) DIST=next ;;
+            *)   DIST=latest ;;
+          esac
+          echo "publishing $V under dist-tag $DIST"
+          npm publish --access public --tag "$DIST"
 
   # Runs git and nothing else. No npm install, no project code — so the
   # repository-write credential is never in scope while third-party code runs.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,11 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      expect_sha:
+        description: 'Optional: refuse unless main is still at this commit (set by `make publish`)'
+        type: string
+        default: ''
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -86,6 +91,34 @@ jobs:
           test -n "$VERSION" || { echo "::error::could not read package.json version"; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "$VERSION -> tag v$VERSION"
+
+      # RELEASES COME FROM main, INCLUDING FROM THE BUTTON. `gh workflow run
+      # --ref` accepts any branch or tag, and the Makefile's `main` guard only
+      # binds callers who went through `make publish` — so without this the
+      # Actions UI or a stray API call could publish and tag a feature branch,
+      # irreversibly.
+      - name: Dispatches must come from main
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "::error::dispatch ref is $GITHUB_REF_NAME; releases must come from main"
+            exit 1
+          fi
+
+      # `--ref main` names a MUTABLE branch, so between `make publish` pushing
+      # the release commit and this run resolving, another commit can land and
+      # be published under the version just bumped. `make publish` passes the
+      # SHA it pushed; if main has moved since, stop rather than release
+      # something nobody asked for.
+      - name: main must still be the commit we intended to release
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.expect_sha != '' }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_SHA" != "${{ inputs.expect_sha }}" ]; then
+            echo "::error::main has moved: expected ${{ inputs.expect_sha }}, got $GITHUB_SHA"
+            exit 1
+          fi
 
       # A tag pushed by hand must agree with the version it claims to release.
       # Without this, pushing v1.2.3 while package.json still says 1.2.2
@@ -174,8 +207,21 @@ jobs:
         run: |
           set -euo pipefail
           TAG="v${{ needs.publish.outputs.version }}"
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "$TAG already exists — nothing to do" >> "$GITHUB_STEP_SUMMARY"
+          HEAD_SHA="$(git rev-parse HEAD)"
+
+          # EXISTENCE IS NOT ENOUGH. `git rev-parse --verify` only asks whether
+          # the name resolves; a tag created between the publish job's guard
+          # and this checkout could point anywhere. Treating that as the
+          # idempotent case would leave a green run with an npm artifact from
+          # THIS commit and a release tag on a different one. Dereference and
+          # compare.
+          AT="$(git rev-parse -q --verify "refs/tags/$TAG^{commit}" 2>/dev/null || true)"
+          if [ -n "$AT" ]; then
+            if [ "$AT" != "$HEAD_SHA" ]; then
+              echo "::error::$TAG exists on $AT, not this commit ($HEAD_SHA)"
+              exit 1
+            fi
+            echo "$TAG already points here — nothing to do" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           git tag "$TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,47 @@
-# Publishes @voxgig/create-sdkgen to npm on a `v*` tag push, via GitHub
-# OIDC Trusted Publishing — no NPM_TOKEN secret. The `id-token: write`
-# permission lets npm exchange a GitHub OIDC token for a short-lived
-# publish credential, and provenance is attached automatically.
+# Releases @voxgig/create-sdkgen: publishes to npm AND writes the git tag.
 #
-# The trusted publisher must be registered on npmjs.com for
-# voxgig/create-sdkgen against THIS filename (publish.yml); renaming
-# this file breaks publishing until the npm-side config is updated to
-# match.
+# ONE FILE, BECAUSE NPM ALLOWS EXACTLY ONE. A trusted publisher is registered
+# on npmjs.com against a single workflow FILENAME, and every @voxgig package
+# is registered against `publish.yml`. The name itself is arbitrary — other
+# orgs register `release.yml` — but only the ONE registered file can publish,
+# so anything that must accompany a publish has to live inside it. Here that
+# is the tag.
 #
-# Release flow: bump package.json, merge to main, then push a v* tag.
+# A second workflow cannot publish whatever permissions it holds; npm rejects
+# the exchange and reports it as
+#
+#   npm error 404 Not Found - PUT https://registry.npmjs.org/...
+#
+# — a 404, not a 403, so as not to leak whether the package exists.
+#
+# TWO JOBS, BECAUSE THEY NEED DIFFERENT PRIVILEGES.
+#
+#   publish  id-token: write, contents: READ. Runs npm ci, the build and the
+#            tests — i.e. dependency lifecycle scripts and project code.
+#   tag      contents: write. Runs git and nothing else.
+#
+# Keeping them in one job would hand a repository-write credential to every
+# dependency postinstall script that runs during `npm ci`, because checkout
+# persists its token into the git config for the whole job.
+#
+# A ref pushed with GITHUB_TOKEN does NOT start another workflow run (GitHub
+# suppresses that so workflows cannot trigger themselves), so the tag job
+# cannot be replaced by "tag and let the publisher fire on it".
+#
+# TWO WAYS IN:
+#
+#   workflow_dispatch  the normal path. Publishes if missing, then tags.
+#   push: tags v*      the manual path, for a tag pushed by hand. Publishes
+#                      only; the tag job does not run.
+#
+# VERSION BUMPS ARE NOT AUTOMATED, deliberately. Nothing here commits. It
+# reads the version already on the branch and releases exactly that, so the
+# bump stays a reviewable diff and the release stays a button.
+#
+#   package.json "version" -> tag v<version>
+#
+# Renaming this file breaks publishing until the npm-side trusted publisher is
+# updated to match. Do NOT publish locally over a token: that bypasses OIDC.
 
 name: publish
 
@@ -17,31 +50,134 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     name: npm publish
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+
+    # Deliberately NOT contents: write — see the header. This job runs
+    # dependency lifecycle scripts.
     permissions:
       id-token: write
       contents: read
 
+    outputs:
+      version: ${{ steps.versions.outputs.version }}
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Resolve the version being released
+        id: versions
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          test -n "$VERSION" || { echo "::error::could not read package.json version"; exit 1; }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "$VERSION -> tag v$VERSION"
+
+      # A tag pushed by hand must agree with the version it claims to release.
+      # Without this, pushing v1.2.3 while package.json still says 1.2.2
+      # resolves 1.2.2, finds it already published, skips the publish, and the
+      # run goes GREEN — leaving a tag with no release behind it.
+      - name: The pushed tag must match the package version
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          set -euo pipefail
+          WANT="v${{ steps.versions.outputs.version }}"
+          if [ "$GITHUB_REF_NAME" != "$WANT" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match package.json ($WANT)"
+            exit 1
+          fi
+
+      # AN EXISTING TAG IS ONLY A PROBLEM IF IT POINTS SOMEWHERE ELSE. A tag
+      # already on this commit is the idempotent case — nothing to create, not
+      # an error — which is what lets a partly-failed release be re-dispatched.
+      - name: Refuse a tag that points at a different commit
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.versions.outputs.version }}"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          AT="$(git rev-parse -q --verify "refs/tags/$TAG^{commit}" 2>/dev/null || true)"
+          if [ -n "$AT" ] && [ "$AT" != "$HEAD_SHA" ]; then
+            echo "::error::tag $TAG already exists on $AT, not this commit — bump package.json"
+            exit 1
+          fi
+          if [ -n "$AT" ]; then echo "$TAG already points here; nothing to create"; fi
+
+      - name: Build and test
+        working-directory: .
+        run: |
+          npm ci
+          npm run build
+          npm test
+
       # Trusted publishing requires npm >= 11.5.1.
       - name: Use a trusted-publishing capable npm
         run: npm install -g npm@latest
 
-      # package-lock.json is committed here, so ci is safe and reproducible.
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
+      # THE REGISTRY IS THE SOURCE OF TRUTH FOR "IS THIS RELEASED", not the
+      # tag. A run can publish and then fail before tagging, leaving a version
+      # on npm with nothing pointing at it. Without this check that state is
+      # unrecoverable: the publish step dies on "cannot publish over the
+      # previously published versions" before the tag job ever runs.
+      - name: Is this version already on npm?
+        id: registry
+        run: |
+          set -euo pipefail
+          V="${{ steps.versions.outputs.version }}"
+          if npm view "@voxgig/create-sdkgen@$V" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "$V is already on npm — skipping publish"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "$V is not on npm — will publish"
+          fi
 
+      # Publish BEFORE tagging (the tag job `needs` this one), so a tag only
+      # ever exists for a release that reached the registry.
       - name: Publish to npm
+        if: ${{ steps.registry.outputs.published == 'false' }}
+        working-directory: .
         run: npm publish --access public
+
+  # Runs git and nothing else. No npm install, no project code — so the
+  # repository-write credential is never in scope while third-party code runs.
+  tag:
+    name: tag
+    needs: publish
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Tag the release
+        run: |
+          set -euo pipefail
+          TAG="v${{ needs.publish.outputs.version }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "$TAG already exists — nothing to do" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
+          echo "pushed $TAG" >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Release automation for @voxgig/create-sdkgen.
+#
+# The npm package lives at the repository root here, so npm runs from the
+# root rather than a ts/ subdirectory.
+
+.PHONY: publish
+
+# ONE COMMAND RELEASES THIS PACKAGE.
+#
+#   make publish V=0.18.0
+#
+# Bumps package.json (and its lockfile) via `npm version
+# --no-git-tag-version`, runs the full suite, commits, pushes main, and
+# dispatches publish.yml — which publishes to npm and writes the v<V> tag.
+#
+# Every guard runs BEFORE anything is written, because a release cannot be
+# taken back: npm never allows republishing a version.
+#
+# There is deliberately no version input on the workflow itself; it reads
+# package.json, so the dispatch and the file cannot disagree.
+publish:
+	@test -n "$(V)" || (echo "Usage: make publish V=x.y.z" && exit 1)
+	@echo "$(V)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$$' || \
+	  (echo "publish: V=$(V) is not a semver x.y.z" && exit 1)
+	@command -v gh >/dev/null 2>&1 || \
+	  (echo "publish: needs the gh CLI to dispatch the workflow" && exit 1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || \
+	  (echo "publish: must be on main (currently $$(git rev-parse --abbrev-ref HEAD))" && exit 1)
+	@test -z "$$(git status --porcelain)" || \
+	  (echo "publish: working tree is not clean" && exit 1)
+	@git fetch origin main --quiet && test -z "$$(git rev-list HEAD..origin/main)" || \
+	  (echo "publish: local main is behind origin/main" && exit 1)
+	@if git rev-parse -q --verify "refs/tags/v$(V)" >/dev/null 2>&1; then \
+	  echo "publish: tag v$(V) already exists"; exit 1; fi
+	npm version --no-git-tag-version $(V)
+	npm ci && npm run build && npm test
+	git add package.json package-lock.json
+	git commit -m "$(V)"
+	git push origin main
+	gh workflow run publish.yml --ref main
+	@echo
+	@echo "dispatched. watch with:  gh run list --workflow=publish.yml --limit 1"

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,15 @@
 # package.json, so the dispatch and the file cannot disagree.
 publish:
 	@test -n "$(V)" || (echo "Usage: make publish V=x.y.z" && exit 1)
-	@echo "$(V)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$$' || \
-	  (echo "publish: V=$(V) is not a semver x.y.z" && exit 1)
+	@echo "$(V)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$$' || \
+	  (echo "publish: V=$(V) is not a semver x.y.z (build metadata is not accepted)" && exit 1)
+	@# NO `+build` METADATA. npm canonicalizes 1.2.3+meta to 1.2.3, so every
+	@# guard here would check v1.2.3+meta while the workflow publishes and tags
+	@# v1.2.3 — the tag-already-exists check would look at the wrong name and
+	@# this target would push a bump for a release the workflow then refuses.
+	@case "$(V)" in \
+	  *+*) echo "publish: V=$(V) carries +build metadata, which npm discards"; exit 1 ;; \
+	esac
 	@command -v gh >/dev/null 2>&1 || \
 	  (echo "publish: needs the gh CLI to dispatch the workflow" && exit 1)
 	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || \
@@ -30,10 +37,10 @@ publish:
 	  (echo "publish: working tree is not clean" && exit 1)
 	@git fetch origin main --quiet && test -z "$$(git rev-list HEAD..origin/main)" || \
 	  (echo "publish: local main is behind origin/main" && exit 1)
-	# ASK THE REMOTE, NOT THE CLONE. `git fetch origin main` does not fetch
-	# tags, so a local rev-parse happily passes in a fresh or stale clone
-	# while v$(V) already exists on origin — and by the time the workflow
-	# refuses, this target has already bumped and pushed main.
+	@# ASK THE REMOTE, NOT THE CLONE. `git fetch origin main` does not fetch
+	@# tags, so a local rev-parse happily passes in a fresh or stale clone
+	@# while v$(V) already exists on origin — and by the time the workflow
+	@# refuses, this target has already bumped and pushed main.
 	@if git ls-remote --exit-code --tags origin "refs/tags/v$(V)" >/dev/null 2>&1; then \
 	  echo "publish: tag v$(V) already exists on origin"; exit 1; fi
 	@if git rev-parse -q --verify "refs/tags/v$(V)" >/dev/null 2>&1; then \
@@ -43,9 +50,9 @@ publish:
 	git add package.json package-lock.json
 	git commit -m "$(V)"
 	git push origin main
-	# `--ref main` is a MOVING target: another commit can land between the
-	# push above and the run resolving, and get published under the
-	# version just bumped. Pin the dispatch to the SHA we pushed.
+	@# `--ref main` is a MOVING target: another commit can land between the
+	@# push above and the run resolving, and get published under the
+	@# version just bumped. Pin the dispatch to the SHA we pushed.
 	gh workflow run publish.yml --ref main -f expect_sha=$$(git rev-parse HEAD)
 	@echo
 	@echo "dispatched. watch with:  gh run list --workflow=publish.yml --limit 1"

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,22 @@ publish:
 	  (echo "publish: working tree is not clean" && exit 1)
 	@git fetch origin main --quiet && test -z "$$(git rev-list HEAD..origin/main)" || \
 	  (echo "publish: local main is behind origin/main" && exit 1)
+	# ASK THE REMOTE, NOT THE CLONE. `git fetch origin main` does not fetch
+	# tags, so a local rev-parse happily passes in a fresh or stale clone
+	# while v$(V) already exists on origin — and by the time the workflow
+	# refuses, this target has already bumped and pushed main.
+	@if git ls-remote --exit-code --tags origin "refs/tags/v$(V)" >/dev/null 2>&1; then \
+	  echo "publish: tag v$(V) already exists on origin"; exit 1; fi
 	@if git rev-parse -q --verify "refs/tags/v$(V)" >/dev/null 2>&1; then \
-	  echo "publish: tag v$(V) already exists"; exit 1; fi
+	  echo "publish: tag v$(V) already exists locally"; exit 1; fi
 	npm version --no-git-tag-version $(V)
 	npm ci && npm run build && npm test
 	git add package.json package-lock.json
 	git commit -m "$(V)"
 	git push origin main
-	gh workflow run publish.yml --ref main
+	# `--ref main` is a MOVING target: another commit can land between the
+	# push above and the run resolving, and get published under the
+	# version just bumped. Pin the dispatch to the SHA we pushed.
+	gh workflow run publish.yml --ref main -f expect_sha=$$(git rev-parse HEAD)
 	@echo
 	@echo "dispatched. watch with:  gh run list --workflow=publish.yml --limit 1"


### PR DESCRIPTION
Ports the release path apidef arrived at, including the four defects a review round found there.

```sh
make publish V=0.18.0
```

This repo had **no Makefile**, so one is created carrying the publish target. The npm package lives at the **repository root** here rather than in `ts/`, so npm runs from the root and the workflow sets `working-directory` accordingly — the one place the three ports differ.

## Two jobs, because they need different privileges

| job | permissions | runs |
| --- | --- | --- |
| `publish` | `id-token: write`, **`contents: read`** | `npm ci`, build, tests, publish |
| `tag` | **`contents: write`** | git, and nothing else |

`checkout` persists its token into the git config for the **whole job**, so combining them would hand a repository-write credential to every dependency `postinstall` during `npm ci`.

## Why tagging lives in the publishing file

**npm allows exactly one trusted-publisher workflow filename per package**, and every `@voxgig` package registers `publish.yml`. The name is arbitrary — other orgs register `release.yml` — but only the registered file can publish.

A second workflow gets rejected as a **404, not a 403** (npm avoids leaking package existence), which reads like the package is missing and sends you hunting the wrong bug.

## Guards

- An existing tag is refused only if it points at a **different** commit — one already here is the idempotent case, which lets a partly-failed release be re-dispatched.
- The **registry**, not the tag, decides "is this released": a version already on npm is checked and skipped rather than assumed, and tagging proceeds regardless. Without it, a run that published then failed to tag leaves an unrecoverable state.
- Publish precedes tag by job dependency, so a tag only ever exists for a release that reached the registry.
- `make publish` validates the semver shape first, before `gh`/branch/clean/up-to-date.

**No version input, deliberately** — the workflow reads `package.json`, so the dispatch and the file cannot disagree.

Verified: workflow YAML parses with both jobs' permissions confirmed; `make publish` emits root-level `npm version`, `npm ci && npm run build && npm test`, and `git add package.json package-lock.json`; `V=9.9` rejected as non-semver.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXgGzj8NmYDbYmj8jMRrNd)_