### PR TITLE
release 0.18.0: publish the corpus contract the SDK test guard requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@voxgig/create-sdkgen",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@voxgig/create-sdkgen",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@voxgig/util": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voxgig/create-sdkgen",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "main": "dist/create-sdkgen.js",
   "type": "commonjs",
   "types": "dist/create-sdkgen.d.ts",


### PR DESCRIPTION
Version bump only — `package.json` and `package-lock.json`, `0.17.2` → `0.18.0`. Nothing else changes; the release itself is the workflow dispatch that follows.

## Why now

`main` has been **18 commits ahead of npm at an identical version number** (`0.17.2` on both sides), so nothing about the version revealed the drift. That is not cosmetic: **every SDK scaffolded from the published package fails its own corpus guard.**

`b99473a` changed the test-corpus deferral marker from a **comment** to **data** (`basic: pending`) and promoted `makePoint` from an empty deferred set to seven real cases. The corpus guard that `@voxgig/sdkgen` generates reads the data marker. Published `0.17.2` predates that commit, so it ships comment-only markers and an empty `makePoint`.

## Measured, not assumed

Against sdk-validate, 3 specs × 6 targets, using published create-sdkgen:

| target | result |
| --- | --- |
| ts | 196/198 (petstore), 189/191 (solar) — 2 failures per spec |
| go | `FAIL rc=2` per spec |
| js, py, php, rb | pass |

Overlaying this branch's corpus onto a failed project and regenerating — changing nothing else — takes **ts to 198/198** and **go to `ok`**. The failure reproduces identically on petstore, solar and taxonomy, so it is a property of the fixtures, not of any one spec.

The competing hypothesis was checked rather than dismissed: sdkgen's `main` genuinely has changed source since its published 3.7.2 (#80/#81/#86/#87 touched `opShape.ts`, `sdkgen.ts`, and the test-generating scaffold), so a regression there was plausible. The fixture evidence rules it out — the failing assertion is about corpus data the scaffold pulls from npm, not about generated code.

## Also carried since 0.17.2

- the release path itself: OIDC publish + tag in one dispatch, the two-job privilege split, and the full guard set
- every action pinned to a full-length commit SHA and moved onto the node24 runtime
- scaffold correctness fixes for inactive root entities and unresolvable `--def` paths

## Verified on this commit

`npm ci` clean, **39/39 tests pass**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXgGzj8NmYDbYmj8jMRrNd)_