### PR TITLE
A test run that executes zero tests is not a pass

### DIFF
--- a/build/check-tests.js
+++ b/build/check-tests.js
@@ -1,0 +1,43 @@
+// A test run that executes ZERO tests must not report success.
+//
+// `npm test` globs `dist-test/**/*.test.js`. When the TypeScript build fails,
+// `noEmitOnError` leaves dist-test/ with nothing in it, the glob matches
+// nothing, and `node --test` exits 0 having run nothing at all:
+//
+//   ℹ tests 0
+//   ℹ pass 0
+//   ℹ fail 0
+//
+// That is indistinguishable from a green suite. It is reachable through this
+// repo's own scripts - `npm run clean` removes dist-test/ (which IS committed),
+// so `reset` and `repo-publish` both pass through the window where a broken
+// build yields a passing test run.
+//
+// CI is protected only because `npm run build` is a separate step that fails
+// first. Anyone running `npm test` by hand after a failed build is not.
+//
+// This runs as `pretest`, so it guards every path into the runner.
+
+const Fs = require('node:fs')
+const Path = require('node:path')
+
+const DIST_TEST = Path.join(__dirname, '..', 'dist-test')
+
+function compiledTests(dir) {
+  if (!Fs.existsSync(dir)) return []
+  return Fs.readdirSync(dir, { recursive: true })
+    .filter((f) => 'string' === typeof f && f.endsWith('.test.js'))
+}
+
+const found = compiledTests(DIST_TEST)
+
+if (0 === found.length) {
+  console.error(
+    'no compiled tests in dist-test/ — nothing would run, and `node --test` ' +
+    'reports that as a PASS.\n' +
+    'Run `npm run build` first; if it fails, that failure is the real problem ' +
+    '(noEmitOnError leaves dist-test/ empty).')
+  process.exit(1)
+}
+
+console.log(found.length + ' compiled test file(s) in dist-test/')

--- a/build/check-tests.js
+++ b/build/check-tests.js
@@ -16,7 +16,11 @@
 // CI is protected only because `npm run build` is a separate step that fails
 // first. Anyone running `npm test` by hand after a failed build is not.
 //
-// This runs as `pretest`, so it guards every path into the runner.
+// This runs as `pretest` AND `pretest-some`. npm only associates a `pre`
+// hook with the script of that exact name, so one hook guards one entry
+// point - `test-some` bypassed a `pretest`-only guard entirely and still
+// reported `tests 0` with exit 0. Every script that reaches the runner
+// needs its own hook.
 
 const Fs = require('node:fs')
 const Path = require('node:path')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "scripts": {
     "pretest": "node build/check-tests.js",
-  "test": "node --enable-source-maps --test dist-test/**/*.test.js",
+    "test": "node --enable-source-maps --test dist-test/**/*.test.js",
+    "pretest-some": "node build/check-tests.js",
     "test-some": "node --enable-source-maps --test-name-pattern=\"$npm_config_pattern\" --test dist-test/**/*.test.js",
     "watch": "tsc --build src test -w",
     "build": "tsc --build src test",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "create-sdkgen": "bin/create-sdkgen"
   },
   "scripts": {
-    "test": "node --enable-source-maps --test dist-test/**/*.test.js",
+    "pretest": "node build/check-tests.js",
+  "test": "node --enable-source-maps --test dist-test/**/*.test.js",
     "test-some": "node --enable-source-maps --test-name-pattern=\"$npm_config_pattern\" --test dist-test/**/*.test.js",
     "watch": "tsc --build src test -w",
     "build": "tsc --build src test",


### PR DESCRIPTION
`npm test` globs `dist-test/**/*.test.js`. When the TypeScript build fails, `noEmitOnError` leaves `dist-test/` empty, the glob matches nothing, and `node --test` exits **0** having run nothing:

```
ℹ tests 0
ℹ pass 0
ℹ fail 0
```

That is indistinguishable from a green suite.

It is reachable through this repo's own scripts. `npm run clean` removes `dist-test/` — which **is** committed — so both `reset` and `repo-publish` pass through a window where a broken build yields a passing test run. CI escapes it only because `npm run build` is a separate step that fails first; anyone running `npm test` by hand after a failed build does not.

Adds `build/check-tests.js`, which names the real cause in its message.

## One hook guards one entry point

The first cut wired it as `pretest` alone. Codex caught that this still left `test-some` unguarded, and it was right: npm associates a `pre` hook only with the script of that **exact** name, so `npm run test-some --pattern=...` reached the runner and still reported `tests 0` with exit 0 — the same false green, through the other door.

Both `pretest` and `pretest-some` now run the checker, and that generalisation is recorded in the guard's own comment so the next script added here gets its own hook.

(Reproducing it took two attempts worth noting: without `--pattern`, `test-some` dies on `--test-name-pattern= requires an argument` (exit 9), which is a *different* failure and does not demonstrate the bug.)

## Verification

Both entry points, both directions, on Node 24:

| | `dist-test/` removed | restored |
| --- | --- | --- |
| `npm test` | exit **1**, names the cause | **54/54** |
| `npm run test-some` | exit **1**, names the cause | **12/12** |

## Context

This came out of a false-green hunt in voxgig/sdkgen#96, where several defects were sitting behind tests that could not fail for the reason they existed. This is the same shape, one repo over — and the `test-some` miss above is the same shape again, one script over.

Worth noting what this is *not*: while investigating I wrongly reported this repo's build as broken. It isn't — `dist/` and `dist-test/` are committed, and a "clean room" that deletes them leaves the test tree unable to resolve `../`. CI was right throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_019YBboWH5De1UyciCCXv8kh)_