### PR TITLE
test: pin explicit auth shape in the canonical prepareAuth corpus fixture

### DIFF
--- a/project/standard/.sdk/test/primary/prepareAuth.aon
+++ b/project/standard/.sdk/test/primary/prepareAuth.aon
@@ -1,6 +1,11 @@
 
 DEF: {
-  setup: a: { apikey: 'APIKEY01' }
+  # auth pinned explicitly (not left to a spec's own derived prefix/scheme):
+  # this corpus tests the raw single-token mechanics in isolation, so it
+  # must not silently inherit whatever a given SDK's real spec declares
+  # (e.g. genuine HTTP Basic Auth, a non-empty prefix, two credentials) -
+  # that has its own dedicated coverage elsewhere.
+  setup: a: { apikey: 'APIKEY01', auth: { prefix: '', basic: false } }
 }
 
 


### PR DESCRIPTION
## Summary
- The generic `prepareAuth` corpus fixture (`project/standard/.sdk/test/primary/prepareAuth.aon`, copied into every scaffolded SDK) never declared an auth scheme, so its test silently inherited whatever a given SDK's real spec resolves for `auth.prefix`/`auth.basic`.
- That was harmless while every SDK used single-token auth, but breaks the moment a spec genuinely resolves to HTTP Basic Auth (non-empty prefix, two credentials) — the fixture's setup only ever supplied `apikey`.
- Pins `auth: { prefix: '', basic: false }` explicitly in the fixture's setup, so this corpus tests the raw single-token mechanics in isolation, independent of any one SDK's actual scheme.

## Found via
Adding real HTTP Basic Auth support to sdkgen's TS target (see companion PR [voxgig/sdkgen#99](https://github.com/voxgig/sdkgen/pull/99)) and regenerating `dtone-sdk` — the first SDK in this fleet whose spec actually resolves to `type: http, scheme: basic`. Its `auth-basic` test started failing not because of a bug, but because the fixture had always been implicitly relying on every spec resolving to a raw, unprefixed single token — an assumption that no longer universally holds.

## Test plan
- [x] Applied the identical fix to `dtone-sdk`'s own local copy of this fixture and confirmed its full test suite passes (187/187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)