### PR TITLE
Raise scaffold dependency floors to sdkgen 4.4.1's peer set

### DIFF
--- a/project/standard/.sdk/package.json
+++ b/project/standard/.sdk/package.json
@@ -27,9 +27,9 @@
     "@voxgig/apidef": ">=8.0",
     "@voxgig/model": ">=10.0",
     "@voxgig/sdkgen": ">=4.0",
-    "@voxgig/util": ">=0.4",
-    "@voxgig/struct": ">=0.1.0",
-    "jostraca": ">=0.29",
-    "aontu": ">=0.44"
+    "@voxgig/util": ">=0.5",
+    "@voxgig/struct": ">=0.2",
+    "jostraca": ">=0.33.1",
+    "aontu": ">=0.52"
   }
 }


### PR DESCRIPTION
A fresh scaffold currently fails `npm install` with ERESOLVE: the `.sdk` floors (`aontu >=0.44`, `jostraca >=0.29`, `@voxgig/struct >=0.1.0`, `@voxgig/util >=0.4`) leave the resolver free to settle on aontu 0.46.0, which then conflicts with `@voxgig/sdkgen` 4.4.1's peer requirement of `aontu >=0.52`. Nothing pins 0.46; the loose floors just permit it.

Raise the four floors to the peers sdkgen actually declares (`aontu >=0.52`, `jostraca >=0.33.1`, `@voxgig/struct >=0.2`, `@voxgig/util >=0.5`), so a consistent set is the only resolution.

Found scaffolding [voxgig-sdk/voxgig-elementdemo-sdk](https://github.com/voxgig-sdk/voxgig-elementdemo-sdk) (the customization demo): the very first `create-sdkgen` run died in `generate-install`. With the floors raised, the same scaffold completes and the generated project installs, generates and tests clean.

Validation: `npm test` 54 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6GayAxxVpe2srRAXs2EWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6GayAxxVpe2srRAXs2EWH)_