### PR TITLE
ci template: unblock go-mcp on Go 1.25, activate opam switch for ocaml

### DIFF
--- a/project/standard/.github/workflows/ci.yml
+++ b/project/standard/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - if: hashFiles('go-mcp/go.mod') != ''
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - if: hashFiles('go-mcp/go.mod') != ''
         run: |
           cd go-mcp
@@ -369,7 +369,10 @@ jobs:
         with:
           ocaml-compiler: '5.2'
       - if: hashFiles('ocaml/Makefile') != ''
-        run: make -C ocaml test
+        # setup-ocaml installs the compiler into an opam switch; without
+        # `opam exec` the switch is not on PATH and make dies with
+        # `ocamlc: No such file or directory` (exit 127).
+        run: opam exec -- make -C ocaml test
 
   haskell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two jobs in `project/standard/.github/workflows/ci.yml` — the CI workflow every scaffolded SDK repo gets — could not pass as written. Both were diagnosed and fixed downstream in voxgig-sdk/bluefin-shieldconex-sdk#1, where the fixed workflow is now green across all 24 CI jobs.

## 1. `go-mcp`: bump the setup-go pin from `1.24` to `1.25`

The scaffolded `go-mcp/go.mod` declares `go 1.25.0` because it depends on `modelcontextprotocol/go-sdk`, while the job pinned Go 1.24. `actions/setup-go` sets `GOTOOLCHAIN=local`, so Go refuses to fetch the newer toolchain and the job dies before compiling anything:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

`go-mcp` is a **blocking** job, so no PR in any scaffolded SDK repo could go green.

Only this pin moves. The `go` and `go-cli` jobs stay at `1.24` — the scaffolded `go/go.mod` is `go 1.21` and `go-cli/go.mod` is `go 1.24.7`, both satisfied by 1.24.

Verified downstream: all four steps of the job (`go mod tidy`, `go vet`, `go build`, `go test`) pass under Go 1.25.

## 2. `ocaml`: run the test step through `opam exec`

`ocaml/setup-ocaml` installs the compiler into an opam switch that has to be activated. Without `opam exec`, `ocamlc` is not on `PATH` and the step exits 127 before compiling a line — so the ocaml job never actually tested anything, it only ever reported an environment error.

```yaml
- if: hashFiles('ocaml/Makefile') != ''
  run: opam exec -- make -C ocaml test
```

Note: fixing this downstream exposed 7 genuine test failures that had been hidden behind the environment error. Those are fixed separately in a companion PR in **voxgig/sdkgen**, so this job becomes meaningfully green only once that lands. The job is `continue-on-error: true` (advisory tier), so it does not block in the meantime.

## Validation

- The template here was byte-identical to the pre-fix workflow in voxgig-sdk/bluefin-shieldconex-sdk#1, and after these two edits is byte-identical to the version that passed CI there.
- YAML parses; 24 jobs; only the intended two hunks changed (5 insertions, 2 deletions).
- This repo's own suite with the patch applied: `npm install && npm run build && npm test` — **54 tests, 54 pass, 0 fail**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqNyBxpAK9Zjaz1jvjg1x9)_